### PR TITLE
2sxc and bootstrap class additions for stretched-link

### DIFF
--- a/src/tailwind/2sxc-content-app-bs5.css
+++ b/src/tailwind/2sxc-content-app-bs5.css
@@ -196,6 +196,10 @@ Content App v17+ and the style we need that is NOT already covered by TW4+.
     bottom: 0 !important;
   }
 
+  .co-linkblock {
+    position: relative;
+  }
+
   .stretched-link::after {
     position: absolute;
     top: 0;

--- a/src/tailwind/bs5-favs.css
+++ b/src/tailwind/bs5-favs.css
@@ -217,3 +217,19 @@
   background-color: var(--swatch-gray-900);
   color: var(--color-white);
 }
+
+/* 
+Bootstrap stretched link utility
+2sxc uses this on some views out of the box
+*/
+.stretched-link::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  pointer-events: auto;
+  content: "";
+  background-color: rgba(0, 0, 0, 0);
+}


### PR DESCRIPTION
This ensures that 2sxc views using Bootstrap work correctly on Tw4 projects. Eventually, we will create our own 2sxc views with only Tailwind classes.